### PR TITLE
Fix navigation drawer background not placed correctly

### DIFF
--- a/kivymd/navigationdrawer.py
+++ b/kivymd/navigationdrawer.py
@@ -29,7 +29,6 @@ navdrawer_kv = '''
 			rgba: self._theme_cls.dialog_background_color
 		Rectangle:
 			size: self.size
-			pos: self.pos
 
 	_header_bg: 	header_bg
 	_bl_items:		bl_items


### PR DESCRIPTION
The NavigationDrawer background is misplaced, because it's using `pos: self.pos` in a SlidingPanel using a RelativeLayout. It's a double pos set, which is why the background is late to come, and for few milliseconds, we're seeing the background of the NavigationDrawer.

PS: good job with your library, i just tested it and i didn't feel i was in a Kivy app :)
